### PR TITLE
商品詳細ページの遷移

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,10 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # コメントアウトして次回実装時に差分が確認できるようにします
-# def show
-#   @item = Item.find(params[:id])
-# end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -101,7 +101,7 @@
       <% if @items.any? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item) do %>
               <div class='item-img-content'>
                 <%# 修正箇所: 画像が存在する場合のみ表示 %>
                 <%= image_tag item.image, class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,77 +4,77 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %> <%# 動的に商品名を表示 %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: "item-box-img" if @item.image.attached? %> <%# 商品画像を動的に表示 %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# if @item.sold_out? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <%# end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= number_to_currency(@item.price, unit: "", delimiter: ",") %> <%# 動的に価格を表示 %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_charge.name %> <%# 配送料負担の情報を動的に表示 %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% if user_signed_in? %>
+      <% if current_user == @item.user %>
+        <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#" , data: { turbo_method: :delete }, class: "item-destroy" %>
+      <% elsif current_user != @item.user %>
+        <%= link_to "購入画面に進む", "#" , class: "item-red-btn" %>
+      <% end %>
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span> <%# 商品説明を動的に表示 %>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %> <%# 出品者名を動的に表示 %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %> <%# カテゴリー名を動的に表示 %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %> <%# 商品の状態を動的に表示 %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %> <%# 配送料の負担を動的に表示 %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %> <%# 発送元の地域を動的に表示 %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %> <%# 発送日の目安を動的に表示 %></td>
         </tr>
       </tbody>
     </table>
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品の通報</span>
       </div>
     </div>
@@ -90,7 +90,7 @@
         不快な言葉遣いなどは利用制限や退会処分となることがあります。
       </p>
       <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
         <span>コメントする<span>
       </button>
     </form>
@@ -104,7 +104,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a> <%# カテゴリー名を動的に表示 %>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,7 +35,6 @@
         <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
       <% end %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span> <%# 商品説明を動的に表示 %>
@@ -103,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a> <%# カテゴリー名を動的に表示 %>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,8 +31,8 @@
         <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#" , data: { turbo_method: :delete }, class: "item-destroy" %>
-      <% elsif current_user != @item.user %>
-        <%= link_to "購入画面に進む", "#" , class: "item-red-btn" %>
+      <% else %>
+        <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
       <% end %>
     <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,14 +25,13 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#" , data: { turbo_method: :delete }, class: "item-destroy" %>
       <% else %>
-        <%= link_to "購入画面に進む", new_order_path(item_id: @item.id), class: "item-red-btn" %>
+        <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:index, :new, :create ]
+  resources :items, only: [:index, :new, :create, :show ]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
# What
- 商品の詳細情報を表示する機能を実装しました。
- 商品出品時に登録された以下の情報を、詳細ページにて動的に表示するようにしました：
  - 商品名
  - 商品画像
  - 価格
  - 配送料の負担
  - 商品の説明
  - 出品者名
  - カテゴリー
  - 商品の状態
  - 発送元の地域
  - 発送日の目安
- ログイン状況や商品の販売状況に応じて、以下のボタンを条件分岐で表示制御しました：
  - 自身が出品した販売中商品の場合：**「商品の編集」「削除」** ボタンを表示。
  - 自身が出品していない販売中商品の場合：**「購入画面に進む」** ボタンを表示。
  - 売却済みの商品では、上記ボタンを全て非表示。
- 商品画像が添付されていない場合のエラーハンドリングを実施しました。

# Why
- 出品者が商品情報を確認しやすくし、購入者が商品の詳細を確認することで購買意欲を高めるため。
- 見本アプリの仕様に準拠し、要件を満たすUI/UXを提供するため。
- ログイン状態や商品の販売状況に応じた条件分岐を実装することで、不正な操作（例：売却済み商品の再購入や削除）を防ぐため。
- 商品画像や詳細情報が適切に表示されることで、エラーやリンク切れが発生しないようにするため。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/017931af847c7caaebbf230bbcd477c5
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/fc8ee7699a8d83aeaa69458076d97f49
ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能未実装
ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/e7e51215eac90f748011901829ce11d0