### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -19,28 +20,20 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+    # @item は before_action で設定済み
   end
 
   def edit
-    @item = Item.find(params[:id])
-
-    # 売却済み商品の場合はトップページにリダイレクト（購入機能語実装の為コメントアウト処理）
-  # if @item.order.present?
-  #   redirect_to root_path
-  # end
+    # 売却済み商品の場合はトップページにリダイレクト（購入機能後実装の為コメントアウト処理）
+    # if @item.order.present?
+    #   redirect_to root_path
+    # end
 
     redirect_to root_path unless current_user == @item.user
   end
 
   def update
-    @item = Item.find(params[:id])
-
-    # 編集時に画像が未変更の場合、既存の画像を保持
-    if params[:item][:image].nil?
-      params[:item][:image] = @item.image.blob if @item.image.attached?
-    end
-
+    # @item は before_action で設定済み
     # 商品情報の更新処理
     if @item.update(item_params)
       redirect_to item_path(@item), notice: '商品情報が更新されました。'
@@ -50,6 +43,10 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :shipping_charge_id, :prefecture_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,12 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+
+    # 売却済み商品の場合はトップページにリダイレクト（購入機能語実装の為コメントアウト処理）
+  # if @item.order.present?
+  #   redirect_to root_path
+  # end
+
     redirect_to root_path unless current_user == @item.user
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,11 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user == @item.user
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -25,6 +25,22 @@ class ItemsController < ApplicationController
   def edit
     @item = Item.find(params[:id])
     redirect_to root_path unless current_user == @item.user
+  end
+
+  def update
+    @item = Item.find(params[:id])
+
+    # 編集時に画像が未変更の場合、既存の画像を保持
+    if params[:item][:image].nil?
+      params[:item][:image] = @item.image.blob if @item.image.attached?
+    end
+
+    # 商品情報の更新処理
+    if @item.update(item_params)
+      redirect_to item_path(@item), notice: '商品情報が更新されました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item), method: :patch, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <% render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -142,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,7 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: item_path(@item), method: :patch, local: true do |f| %>
 
-    <% render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#" , data: { turbo_method: :delete }, class: "item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:index, :new, :create, :show ]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update ]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
# What
商品情報編集機能を実装しました。この機能では、以下の仕様を満たしています：
1. ログインしている出品者のみが編集ページに遷移できるように制御。
2. 商品画像を含む全ての情報が編集できるように実装。
3. 編集完了後、正しくデータベースが更新され、商品詳細ページにリダイレクトする動作を確認済み。
4. 入力内容にエラーがある場合は、編集ページにエラーメッセージを表示し、変更が保存されないように処理。
5. 売却済み商品の編集制限に関する実装は、コメントアウトでコードに含めて今後対応予定。

# Why
この機能は、ユーザーが出品した商品の情報を柔軟に管理・編集できるようにするために実装しました。
- 出品者自身が商品情報を更新できることで、より正確な情報提供を可能にする。
- バリデーションとエラーハンドリングを実装することで、ユーザーエクスペリエンスの向上とデータの一貫性を維持。
- 編集時のセキュリティ対策（出品者のみが編集可能）を確保し、不正アクセスや改ざんを防止。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/15662b414f4eb743e2dd7dc4b585e850
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/97890d9c9bcdcca0027b22a50bb87674
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/f767b12c92a1c1d8ddd8460a6377d486
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/a37ab290f3c613d0626e114ef456ad99
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/f4be8e078d584b9223bc957ae2f72642
ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
-購入機能未実装
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/547345fbb94eafefbf0dd6148e55ff11
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/eccadb9634c33d8db6cafc72661da83c