### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -24,17 +24,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    # 売却済み商品の場合はトップページにリダイレクト（購入機能後実装の為コメントアウト処理）
-    # if @item.order.present?
-    #   redirect_to root_path
-    # end
-
+    # @item は before_action で設定済み
     redirect_to root_path unless current_user == @item.user
   end
 
   def update
     # @item は before_action で設定済み
-    # 商品情報の更新処理
     if @item.update(item_params)
       redirect_to item_path(@item), notice: '商品情報が更新されました。'
     else
@@ -43,9 +38,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
-  
-    # 自身が出品した商品か確認
     if @item.user == current_user
       @item.destroy
       redirect_to root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,6 +42,18 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+  
+    # 自身が出品した商品か確認
+    if @item.user == current_user
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
   private
 
   def set_item

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to '削除', item_path(@item), data: { turbo_method: :delete }, class: 'delete-btn' %>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class: "item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#" , data: { turbo_method: :delete }, class: "item-destroy" %>
+        <%= link_to '削除', item_path(@item), data: { turbo_method: :delete }, class: 'delete-btn' %>
       <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:index, :new, :create, :show, :edit, :update ]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy ]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
# What
商品削除機能を実装しました。この機能では以下を満たしています：
1. ログイン状態の場合のみ、出品者が自身の商品の削除を実行可能。
2. 削除完了後はトップページにリダイレクト。
3. 削除に関するメッセージ表示は行わず、シンプルに遷移のみを実現。

# Why
この機能は、ユーザーが自身の出品商品を管理するために必要です。
- **セキュリティの確保**: ログインユーザーが出品者であることを確認してから削除を実行することで、商品の誤削除や不正削除を防止。
- **ユーザーエクスペリエンスの向上**: 削除後に通知を表示せず、スムーズにトップページへ遷移することで、操作性を向上。
- **シンプルなロジック**: 必要な部分だけをコードに反映させ、Railsの思想に従ったシンプルで効率的な設計を実現。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/e147609dcd836c018e2f8dddd9125af4